### PR TITLE
Bugfix/return-correct-code-error-when-not-found

### DIFF
--- a/middleware/getJam.ts
+++ b/middleware/getJam.ts
@@ -23,7 +23,7 @@ async function getJam(
   });
 
   if (!jam) {
-    res.status(401).send("Jam missing.");
+    res.status(404).send("Jam missing.");
     return;
   }
 

--- a/middleware/getPostOrComment.ts
+++ b/middleware/getPostOrComment.ts
@@ -24,7 +24,7 @@ async function getPostOrComment(
     });
 
     if (!post) {
-      res.status(401).send("Post missing.");
+      res.status(404).send("Post missing.");
       return;
     }
 
@@ -40,7 +40,7 @@ async function getPostOrComment(
     });
 
     if (!comment) {
-      res.status(401).send("Comment missing.");
+      res.status(404).send("Comment missing.");
       return;
     }
 

--- a/middleware/getTargetUser.ts
+++ b/middleware/getTargetUser.ts
@@ -67,7 +67,7 @@ async function getTargetUser(
   }
 
   if (!user) {
-    res.status(401).send("User missing.");
+    res.status(404).send("User missing.");
     return;
   }
 

--- a/middleware/getUser.ts
+++ b/middleware/getUser.ts
@@ -40,7 +40,7 @@ async function getUser(
   });
 
   if (!user) {
-    res.status(401).send("User missing.");
+    res.status(404).send("User missing.");
     return;
   }
 


### PR DESCRIPTION
When a resource is not found it should return the 404 (not found) response instead of the 401 (Unauthorized) code