### PR TITLE
docs/adding-required-TOKENSECRET-to-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ To run you can first set environment variables for the database in a .env file
 POSTGRES_USER=jammer
 POSTGRES_PASSWORD=INSERTPASSWORDHERE
 POSTGRES_DB=jamcore
+TOKEN_SECRET=RANDOMSTRINGHERE
 ```
 
 And then run


### PR DESCRIPTION
Added 'TOKEN_SECRET' to the .env file in the README since it would crash otherwise when trying to create a user