### PR TITLE
hotfix/comment-on-post-not-working

### DIFF
--- a/routes/v1/comment/post.ts
+++ b/routes/v1/comment/post.ts
@@ -9,7 +9,7 @@ const router = Router();
 /**
  * Route to create a comment.
  */
-router.get(
+router.post(
   "/",
   rateLimit(),
 

--- a/routes/v1/jam/get.ts
+++ b/routes/v1/jam/get.ts
@@ -15,7 +15,8 @@ router.get(
   getJam,
 
   async (_req, res) => {
-    logger.info(`Jam with id ${res.locals.jam.id} fetched`);
+    // if no jam found it crashes the container
+    res.locals.jam && logger.info(`Jam with id ${res.locals.jam.id} fetched`);
     res.send({
       message: "Jam fetched",
       data: { jam: res.locals.jam, phase: res.locals.jamPhase },


### PR DESCRIPTION
HOTFIX: post.ts for comment was a get request instead of post request resulting in 404 errors.

HOTFIX: get jam crashed backend when trying to log when no jams where found